### PR TITLE
Update pca9685.py with new default address

### DIFF
--- a/raspberry pi/python/pca9685.py
+++ b/raspberry pi/python/pca9685.py
@@ -37,7 +37,7 @@ DC_MOTOR_INB2        = 4
 class PCA9685:
     def __init__(self):
         self.i2c = smbus.SMBus(1)
-        self.dev_addr = 0x5f
+        self.dev_addr = 0x7f
         self.write_reg(MODE1, 0x00)
 
     def write_reg(self, reg, value):


### PR DESCRIPTION
The current address of `0x5f` does not work, per the documentation it should be `0x7f` https://seengreat.com/wiki/91/#toc4